### PR TITLE
feat(about): add scroll animations and counter effects (#121)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -400,6 +400,30 @@ All agents should:
 4. Update tests for new functionality
 5. Update their SKILLS.md with session learnings via `/wrap-session`
 
+### Task Delegation Workflow
+
+**When to use `@frontend-dev` agent:**
+
+| Task Type | Approach |
+|-----------|----------|
+| Predefined GitHub issue (e.g., "work on issue #121") | Use `@frontend-dev` agent |
+| Impromptu/ad-hoc tasks or quick questions | Work directly (main conversation) |
+
+**Rationale:** When a specific GitHub issue is mentioned, the requirements are already defined in the issue, so the `@frontend-dev` agent can:
+1. Fetch the issue details from GitHub
+2. Understand the full scope and acceptance criteria
+3. Work autonomously with its specialized project context
+4. Return completed work for review
+
+**Example:**
+```
+User: "Work on issue #121"
+→ Invoke @frontend-dev agent with the issue context
+
+User: "Can you quickly fix this typo?"
+→ Work directly in the main conversation
+```
+
 ---
 
 ## Common Pitfalls & Lessons Learned

--- a/__tests__/app/components/StatsBar.test.tsx
+++ b/__tests__/app/components/StatsBar.test.tsx
@@ -1,7 +1,31 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import StatsBar from '@/app/components/StatsBar/StatsBar';
 import type { StatItem } from '@/app/components/StatsBar/StatsBar';
+
+// Mock IntersectionObserver for scroll reveal
+const mockIntersectionObserver = jest.fn();
+const mockDisconnect = jest.fn();
+const mockObserve = jest.fn();
+
+beforeEach(() => {
+  mockDisconnect.mockClear();
+  mockObserve.mockClear();
+  mockIntersectionObserver.mockClear();
+
+  mockIntersectionObserver.mockImplementation((callback) => ({
+    observe: mockObserve,
+    disconnect: mockDisconnect,
+    unobserve: jest.fn(),
+    root: null,
+    rootMargin: '',
+    thresholds: [],
+    takeRecords: jest.fn(),
+    _callback: callback,
+  }));
+
+  window.IntersectionObserver = mockIntersectionObserver as unknown as typeof IntersectionObserver;
+});
 
 const mockStats: StatItem[] = [
   { value: '10+', label: 'Years' },
@@ -211,6 +235,136 @@ describe('StatsBar Component', () => {
       expect(items[2]).toHaveTextContent('Languages');
       expect(items[3]).toHaveTextContent('1');
       expect(items[3]).toHaveTextContent('Dream Project');
+    });
+  });
+
+  describe('Animation features', () => {
+    test('renders static items when animateOnScroll is false (default)', () => {
+      const { container } = render(<StatsBar stats={mockStats} />);
+      const items = container.querySelectorAll('[role="listitem"]');
+
+      // Static items should have duration-200
+      items.forEach((item) => {
+        expect(item).toHaveClass('duration-200');
+      });
+    });
+
+    test('renders animated items when animateOnScroll is true', () => {
+      const { container } = render(<StatsBar stats={mockStats} animateOnScroll />);
+      const items = container.querySelectorAll('[role="listitem"]');
+
+      // Animated items should have duration-500
+      items.forEach((item) => {
+        expect(item).toHaveClass('duration-500');
+      });
+    });
+
+    test('attaches ref to container when animateOnScroll is true', () => {
+      render(<StatsBar stats={mockStats} animateOnScroll />);
+
+      // Should observe the element
+      expect(mockObserve).toHaveBeenCalled();
+    });
+
+    test('does not attach ref when animateOnScroll is false', () => {
+      render(<StatsBar stats={mockStats} animateOnScroll={false} />);
+
+      // Should not observe any element
+      expect(mockObserve).not.toHaveBeenCalled();
+    });
+
+    test('animated items start with opacity-0 before intersection', () => {
+      const { container } = render(<StatsBar stats={mockStats} animateOnScroll />);
+      const items = container.querySelectorAll('[role="listitem"]');
+
+      // Items should start invisible
+      items.forEach((item) => {
+        expect(item).toHaveClass('opacity-0');
+      });
+    });
+
+    test('animated items become visible after intersection', () => {
+      const { container } = render(<StatsBar stats={mockStats} animateOnScroll />);
+
+      // Trigger intersection
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      const items = container.querySelectorAll('[role="listitem"]');
+      items.forEach((item) => {
+        expect(item).toHaveClass('opacity-100');
+      });
+    });
+
+    test('applies stagger delay to animated items', () => {
+      const { container } = render(
+        <StatsBar stats={mockStats} animateOnScroll staggerDelay={150} />,
+      );
+      const items = container.querySelectorAll('[role="listitem"]');
+
+      // Check stagger delays
+      expect(items[0]).toHaveStyle({ transitionDelay: '0ms' });
+      expect(items[1]).toHaveStyle({ transitionDelay: '150ms' });
+      expect(items[2]).toHaveStyle({ transitionDelay: '300ms' });
+      expect(items[3]).toHaveStyle({ transitionDelay: '450ms' });
+    });
+
+    test('uses default stagger delay of 100ms', () => {
+      const { container } = render(<StatsBar stats={mockStats} animateOnScroll />);
+      const items = container.querySelectorAll('[role="listitem"]');
+
+      expect(items[0]).toHaveStyle({ transitionDelay: '0ms' });
+      expect(items[1]).toHaveStyle({ transitionDelay: '100ms' });
+      expect(items[2]).toHaveStyle({ transitionDelay: '200ms' });
+      expect(items[3]).toHaveStyle({ transitionDelay: '300ms' });
+    });
+
+    test('accepts custom animationDuration prop', () => {
+      // This tests that the prop is passed through
+      // Actual animation duration is handled by useCountUp hook
+      const { container } = render(
+        <StatsBar stats={mockStats} animateOnScroll animationDuration={3000} />,
+      );
+      const items = container.querySelectorAll('[role="listitem"]');
+
+      expect(items).toHaveLength(4);
+    });
+
+    test('parses numeric values from stat value strings', () => {
+      const statsWithSuffix: StatItem[] = [
+        { value: '10+', label: 'Years' },
+        { value: '100%', label: 'Success' },
+      ];
+
+      const { container } = render(<StatsBar stats={statsWithSuffix} animateOnScroll />);
+
+      // Trigger intersection
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      const items = container.querySelectorAll('[role="listitem"]');
+      expect(items).toHaveLength(2);
+    });
+
+    test('uses explicit numericValue when provided', () => {
+      const statsWithNumeric: StatItem[] = [
+        { value: 'N/A', label: 'Years', numericValue: 10, suffix: '+' },
+      ];
+
+      const { container } = render(<StatsBar stats={statsWithNumeric} animateOnScroll />);
+
+      // Trigger intersection
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      const items = container.querySelectorAll('[role="listitem"]');
+      expect(items).toHaveLength(1);
     });
   });
 });

--- a/__tests__/app/hooks/useCountUp.test.tsx
+++ b/__tests__/app/hooks/useCountUp.test.tsx
@@ -1,0 +1,368 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useCountUp, UseCountUpOptions } from '@/app/hooks/useCountUp';
+
+// Mock requestAnimationFrame
+let frameCallbacks: Array<(timestamp: number) => void> = [];
+let frameId = 0;
+let currentTime = 0;
+
+beforeEach(() => {
+  frameCallbacks = [];
+  frameId = 0;
+  currentTime = 0;
+
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    frameCallbacks.push(callback);
+    return ++frameId;
+  });
+
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {
+    // Cancel is a no-op in our mock, but we track it was called
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// Helper to advance animation frames
+function advanceFrames(duration: number, steps = 10) {
+  const stepDuration = duration / steps;
+  for (let i = 0; i < steps; i++) {
+    currentTime += stepDuration;
+    const callbacks = [...frameCallbacks];
+    frameCallbacks = [];
+    callbacks.forEach((cb) => cb(currentTime));
+  }
+}
+
+describe('useCountUp', () => {
+  // Helper component to test the hook
+  const TestComponent = ({ options }: { options: UseCountUpOptions }) => {
+    const result = useCountUp(options);
+    return <span data-testid="result">{result}</span>;
+  };
+
+  describe('Initial state', () => {
+    test('returns start value initially', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: false }} />,
+      );
+
+      expect(getByTestId('result').textContent).toBe('0');
+    });
+
+    test('returns custom start value initially', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ start: 50, end: 100, startCounting: false }} />,
+      );
+
+      expect(getByTestId('result').textContent).toBe('50');
+    });
+
+    test('applies prefix and suffix to initial value', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: false, prefix: '$', suffix: '+' }} />,
+      );
+
+      expect(getByTestId('result').textContent).toBe('$0+');
+    });
+  });
+
+  describe('Counting animation', () => {
+    test('starts counting when startCounting becomes true', () => {
+      const { getByTestId, rerender } = render(
+        <TestComponent options={{ end: 100, startCounting: false }} />,
+      );
+
+      expect(getByTestId('result').textContent).toBe('0');
+
+      rerender(<TestComponent options={{ end: 100, startCounting: true }} />);
+
+      // Animation frame should be requested
+      expect(window.requestAnimationFrame).toHaveBeenCalled();
+    });
+
+    test('reaches end value after animation completes', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 1000 }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100');
+    });
+
+    test('counts up from custom start to end', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ start: 50, end: 100, startCounting: true, duration: 1000 }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100');
+    });
+
+    test('applies suffix to animated value', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 1000, suffix: '+' }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100+');
+    });
+
+    test('applies prefix to animated value', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 1000, prefix: '$' }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('$100');
+    });
+
+    test('applies both prefix and suffix', () => {
+      const { getByTestId } = render(
+        <TestComponent
+          options={{
+            end: 100,
+            startCounting: true,
+            duration: 1000,
+            prefix: '$',
+            suffix: '+',
+          }}
+        />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('$100+');
+    });
+  });
+
+  describe('Easing functions', () => {
+    test('uses linear easing when specified', () => {
+      const { getByTestId } = render(
+        <TestComponent
+          options={{ end: 100, startCounting: true, duration: 1000, easing: 'linear' }}
+        />,
+      );
+
+      // Advance halfway
+      act(() => {
+        advanceFrames(500, 10);
+      });
+
+      // With linear easing, should be around 50 at halfway point
+      const value = parseInt(getByTestId('result').textContent || '0', 10);
+      expect(value).toBeGreaterThanOrEqual(45);
+      expect(value).toBeLessThanOrEqual(55);
+    });
+
+    test('uses easeOutCubic easing by default', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 1000 }} />,
+      );
+
+      // Advance halfway - with easeOutCubic, should be more than 50
+      act(() => {
+        advanceFrames(500, 10);
+      });
+
+      const value = parseInt(getByTestId('result').textContent || '0', 10);
+      // easeOutCubic accelerates early, so should be > 50 at halfway
+      expect(value).toBeGreaterThanOrEqual(50);
+    });
+
+    test('uses easeOutQuart easing when specified', () => {
+      const { getByTestId } = render(
+        <TestComponent
+          options={{ end: 100, startCounting: true, duration: 1000, easing: 'easeOutQuart' }}
+        />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100');
+    });
+  });
+
+  describe('Reduced motion preference', () => {
+    test('sets end value immediately when reduced motion is preferred', () => {
+      const mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, suffix: '+' }} />,
+      );
+
+      // Should immediately show end value without animation
+      expect(getByTestId('result').textContent).toBe('100+');
+    });
+
+    test('does not start animation when reduced motion is preferred', () => {
+      const mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      render(<TestComponent options={{ end: 100, startCounting: true }} />);
+
+      // Animation should not be requested
+      expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Animation lifecycle', () => {
+    test('only starts animation once', () => {
+      const { rerender } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 1000 }} />,
+      );
+
+      // Re-render with same props
+      rerender(<TestComponent options={{ end: 100, startCounting: true, duration: 1000 }} />);
+
+      // Should not start a new animation
+      // Note: RAF may be called during animation, but not a new initialization
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+    });
+
+    test('cleanup function handles unmount gracefully', () => {
+      // This test verifies the component can unmount cleanly during animation
+      // Different end value ensures hasStartedRef doesn't block this test
+      const { unmount, getByTestId } = render(
+        <TestComponent options={{ end: 999, startCounting: true, duration: 2000 }} />,
+      );
+
+      // Verify component mounted
+      expect(getByTestId('result')).toBeInTheDocument();
+
+      // Unmount should not throw (cleanup runs)
+      expect(() => unmount()).not.toThrow();
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('handles zero end value', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ start: 10, end: 0, startCounting: true, duration: 1000 }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('0');
+    });
+
+    test('handles negative end value', () => {
+      // Note: Current implementation may not handle negative values, but this tests current behavior
+      const { getByTestId } = render(
+        <TestComponent options={{ end: -10, startCounting: true, duration: 1000 }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('-10');
+    });
+
+    test('handles large numbers', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 1000000, startCounting: true, duration: 1000 }} />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('1000000');
+    });
+
+    test('handles very short duration', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 10 }} />,
+      );
+
+      act(() => {
+        advanceFrames(50, 5);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100');
+    });
+
+    test('handles empty prefix and suffix', () => {
+      const { getByTestId } = render(
+        <TestComponent
+          options={{ end: 100, startCounting: true, duration: 1000, prefix: '', suffix: '' }}
+        />,
+      );
+
+      act(() => {
+        advanceFrames(1100, 20);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100');
+    });
+  });
+
+  describe('Duration options', () => {
+    test('animation reaches end value when started', () => {
+      // Use unique end value to avoid hasStartedRef collision
+      const { getByTestId } = render(<TestComponent options={{ end: 777, startCounting: true }} />);
+
+      // Advance to completion
+      act(() => {
+        advanceFrames(3000, 30);
+      });
+
+      expect(getByTestId('result').textContent).toBe('777');
+    });
+
+    test('respects custom duration', () => {
+      const { getByTestId } = render(
+        <TestComponent options={{ end: 100, startCounting: true, duration: 500 }} />,
+      );
+
+      act(() => {
+        advanceFrames(600, 10);
+      });
+
+      expect(getByTestId('result').textContent).toBe('100');
+    });
+  });
+});

--- a/__tests__/app/hooks/useScrollReveal.test.tsx
+++ b/__tests__/app/hooks/useScrollReveal.test.tsx
@@ -1,0 +1,380 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useScrollReveal } from '@/app/hooks/useScrollReveal';
+
+// Mock IntersectionObserver
+const mockIntersectionObserver = jest.fn();
+const mockDisconnect = jest.fn();
+const mockObserve = jest.fn();
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockDisconnect.mockClear();
+  mockObserve.mockClear();
+  mockIntersectionObserver.mockClear();
+
+  mockIntersectionObserver.mockImplementation((callback) => ({
+    observe: mockObserve,
+    disconnect: mockDisconnect,
+    unobserve: jest.fn(),
+    root: null,
+    rootMargin: '',
+    thresholds: [],
+    takeRecords: jest.fn(),
+    // Store callback to trigger intersection events
+    _callback: callback,
+  }));
+
+  window.IntersectionObserver = mockIntersectionObserver as unknown as typeof IntersectionObserver;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useScrollReveal', () => {
+  // Helper component to test the hook
+  const TestComponent = ({
+    options = {},
+    onStateChange,
+  }: {
+    options?: Parameters<typeof useScrollReveal>[0];
+    onStateChange?: (state: { isVisible: boolean; prefersReducedMotion: boolean }) => void;
+  }) => {
+    const { ref, isVisible, prefersReducedMotion } = useScrollReveal<HTMLDivElement>(options);
+
+    React.useEffect(() => {
+      onStateChange?.({ isVisible, prefersReducedMotion });
+    }, [isVisible, prefersReducedMotion, onStateChange]);
+
+    return (
+      <div ref={ref} data-testid="target" data-visible={isVisible}>
+        Content
+      </div>
+    );
+  };
+
+  describe('Initial state', () => {
+    test('returns isVisible as false initially', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent onStateChange={(s) => (state = s)} />);
+
+      expect(state.isVisible).toBe(false);
+    });
+
+    test('returns ref that can be attached to element', () => {
+      const { getByTestId } = render(<TestComponent />);
+      expect(getByTestId('target')).toBeInTheDocument();
+    });
+
+    test('creates IntersectionObserver with default options', () => {
+      render(<TestComponent />);
+
+      expect(mockIntersectionObserver).toHaveBeenCalledWith(expect.any(Function), {
+        threshold: 0.1,
+        rootMargin: '0px',
+      });
+    });
+
+    test('creates IntersectionObserver with custom options', () => {
+      render(<TestComponent options={{ threshold: 0.5, rootMargin: '100px' }} />);
+
+      expect(mockIntersectionObserver).toHaveBeenCalledWith(expect.any(Function), {
+        threshold: 0.5,
+        rootMargin: '100px',
+      });
+    });
+  });
+
+  describe('Intersection behavior', () => {
+    test('sets isVisible to true when element intersects', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent onStateChange={(s) => (state = s)} />);
+
+      // Get the callback that was passed to IntersectionObserver
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      // Simulate intersection
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      expect(state.isVisible).toBe(true);
+    });
+
+    test('disconnects observer when once=true (default) after intersection', () => {
+      render(<TestComponent />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    test('does not disconnect observer when once=false', () => {
+      render(<TestComponent options={{ once: false }} />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      expect(mockDisconnect).not.toHaveBeenCalled();
+    });
+
+    test('resets isVisible when element leaves view with once=false', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent options={{ once: false }} onStateChange={(s) => (state = s)} />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      // Enter viewport
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+      expect(state.isVisible).toBe(true);
+
+      // Leave viewport
+      act(() => {
+        observerCallback([{ isIntersecting: false }], { disconnect: mockDisconnect });
+      });
+      expect(state.isVisible).toBe(false);
+    });
+  });
+
+  describe('Delay behavior', () => {
+    test('applies delay before setting isVisible', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent options={{ delay: 500 }} onStateChange={(s) => (state = s)} />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      // Simulate intersection
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      // Should not be visible yet
+      expect(state.isVisible).toBe(false);
+
+      // Advance timers
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(state.isVisible).toBe(true);
+    });
+
+    test('does not apply delay when delay=0', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent options={{ delay: 0 }} onStateChange={(s) => (state = s)} />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      // Should be immediately visible
+      expect(state.isVisible).toBe(true);
+    });
+
+    test('clears timeout when element leaves view with once=false', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(
+        <TestComponent options={{ delay: 500, once: false }} onStateChange={(s) => (state = s)} />,
+      );
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      // Enter viewport
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      // Leave before delay completes
+      act(() => {
+        jest.advanceTimersByTime(200);
+        observerCallback([{ isIntersecting: false }], { disconnect: mockDisconnect });
+      });
+
+      // Advance past original delay
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      // Should not become visible since we left viewport
+      expect(state.isVisible).toBe(false);
+    });
+  });
+
+  describe('Reduced motion preference', () => {
+    test('sets isVisible immediately when reduced motion is preferred', () => {
+      // Mock reduced motion preference
+      const mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent onStateChange={(s) => (state = s)} />);
+
+      // Should be immediately visible
+      expect(state.isVisible).toBe(true);
+      expect(state.prefersReducedMotion).toBe(true);
+    });
+
+    test('does not observe element after reduced motion is detected', async () => {
+      const mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent onStateChange={(s) => (state = s)} />);
+
+      // The key behavior is that isVisible becomes true immediately
+      // and the element is accessible without scroll
+      expect(state.isVisible).toBe(true);
+      expect(state.prefersReducedMotion).toBe(true);
+    });
+
+    test('responds to reduced motion preference change', () => {
+      let mediaQueryCallback: ((e: MediaQueryListEvent) => void) | null = null;
+      const mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn((event: string, cb: (e: MediaQueryListEvent) => void) => {
+          if (event === 'change') {
+            mediaQueryCallback = cb;
+          }
+        }),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent onStateChange={(s) => (state = s)} />);
+
+      expect(state.prefersReducedMotion).toBe(false);
+
+      // Simulate preference change
+      act(() => {
+        mediaQueryCallback?.({ matches: true } as MediaQueryListEvent);
+      });
+
+      expect(state.prefersReducedMotion).toBe(true);
+      expect(state.isVisible).toBe(true);
+    });
+  });
+
+  describe('Cleanup', () => {
+    test('disconnects observer on unmount', () => {
+      const { unmount } = render(<TestComponent />);
+
+      unmount();
+
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    test('clears pending timeout on unmount', () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+      const { unmount } = render(<TestComponent options={{ delay: 1000 }} />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      // Trigger intersection with delay
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+
+      // Unmount before delay completes
+      unmount();
+
+      // clearTimeout should have been called
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+
+      clearTimeoutSpy.mockRestore();
+    });
+
+    test('removes media query listener on unmount', () => {
+      const mockRemoveEventListener = jest.fn();
+      const mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: mockRemoveEventListener,
+        dispatchEvent: jest.fn(),
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      const { unmount } = render(<TestComponent />);
+
+      unmount();
+
+      expect(mockRemoveEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('handles null ref gracefully', () => {
+      // Component that doesn't attach the ref
+      const NoRefComponent = () => {
+        const { isVisible } = useScrollReveal<HTMLDivElement>();
+        return <div data-visible={isVisible}>No ref attached</div>;
+      };
+
+      // Should not throw
+      expect(() => render(<NoRefComponent />)).not.toThrow();
+    });
+
+    test('handles multiple intersection events', () => {
+      let state = { isVisible: false, prefersReducedMotion: false };
+      render(<TestComponent options={{ once: false }} onStateChange={(s) => (state = s)} />);
+
+      const observerCallback = mockIntersectionObserver.mock.calls[0][0];
+
+      // Multiple intersections
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+      expect(state.isVisible).toBe(true);
+
+      act(() => {
+        observerCallback([{ isIntersecting: false }], { disconnect: mockDisconnect });
+      });
+      expect(state.isVisible).toBe(false);
+
+      act(() => {
+        observerCallback([{ isIntersecting: true }], { disconnect: mockDisconnect });
+      });
+      expect(state.isVisible).toBe(true);
+    });
+  });
+});

--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -28,7 +28,7 @@ export default function Page() {
         }
       >
         <div className={'max-sm:w-full flex flex-col max-sm:items-center gap-12'}>
-          <FadeIn>
+          <FadeIn scrollTrigger direction="up">
             <Image
               alt={'me'}
               className={'w-full max-w-[500px]'}
@@ -40,35 +40,47 @@ export default function Page() {
             />
             <span className={'flex justify-center'}>{'-Illustration designed by Gihun Ko'}</span>
           </FadeIn>
-          <div className={'max-sm:w-full max-sm:mt-8'}>
-            <h1 className={h1BaseStyle}>Gihun Ko Stephen</h1>
-            <p className={microTextBaseStyle}>{t('intro')}</p>
-            <NameCard variant="expanded" />
-          </div>
-          <StatsBar stats={stats} />
-          <Section
-            title={t('about_project')}
-            id="about-project"
-            background="gray"
-            className="rounded-lg"
-          >
-            <p className={'whitespace-pre-line font-light text-base leading-relaxed'}>
-              {t('about_project_desc')}
-            </p>
-          </Section>
+          <FadeIn scrollTrigger direction="up" delay={100}>
+            <div className={'max-sm:w-full max-sm:mt-8'}>
+              <h1 className={h1BaseStyle}>Gihun Ko Stephen</h1>
+              <p className={microTextBaseStyle}>{t('intro')}</p>
+              <NameCard variant="expanded" />
+            </div>
+          </FadeIn>
+          <FadeIn scrollTrigger direction="up" delay={200}>
+            <StatsBar stats={stats} animateOnScroll animationDuration={2000} staggerDelay={100} />
+          </FadeIn>
+          <FadeIn scrollTrigger direction="up" delay={300}>
+            <Section
+              title={t('about_project')}
+              id="about-project"
+              background="gray"
+              className="rounded-lg"
+            >
+              <p className={'whitespace-pre-line font-light text-base leading-relaxed'}>
+                {t('about_project_desc')}
+              </p>
+            </Section>
+          </FadeIn>
         </div>
         <div className={'flex flex-col w-full'}>
           <div className={'flex flex-col w-full'}>
-            <Section title={t('food_code')} id="food-code" background="white" className="px-0">
-              <p className={'whitespace-pre-line font-light text-base leading-relaxed'}>
-                {t.rich('food_code_desc', {
-                  b: (chunks) => <span className={'font-bold'}>{chunks}</span>,
-                  i: (chunks) => <span className={'italic'}>{chunks}</span>,
-                })}
-              </p>
-            </Section>
-            <InspirationSection />
-            <TechStackSection />
+            <FadeIn scrollTrigger direction="up" delay={100}>
+              <Section title={t('food_code')} id="food-code" background="white" className="px-0">
+                <p className={'whitespace-pre-line font-light text-base leading-relaxed'}>
+                  {t.rich('food_code_desc', {
+                    b: (chunks) => <span className={'font-bold'}>{chunks}</span>,
+                    i: (chunks) => <span className={'italic'}>{chunks}</span>,
+                  })}
+                </p>
+              </Section>
+            </FadeIn>
+            <FadeIn scrollTrigger direction="up" delay={200}>
+              <InspirationSection />
+            </FadeIn>
+            <FadeIn scrollTrigger direction="up" delay={300}>
+              <TechStackSection />
+            </FadeIn>
           </div>
         </div>
       </div>

--- a/app/components/FadeIn/FadeIn.tsx
+++ b/app/components/FadeIn/FadeIn.tsx
@@ -95,17 +95,12 @@ export default function FadeIn({
 
   const { initial, visible } = directionStyles[direction];
 
-  const baseStyle = cn(
-    'transition-all ease-out',
-    !skipAnimation && `duration-${duration}`,
-  );
+  // Note: Duration is set via inline style since Tailwind JIT doesn't support arbitrary duration classes
+  const baseStyle = cn('transition-all ease-out');
 
   const animationStyle = skipAnimation
     ? 'opacity-100'
-    : cn(
-        isLoaded ? 'opacity-100' : 'opacity-0',
-        isLoaded ? visible : initial,
-      );
+    : cn(isLoaded ? 'opacity-100' : 'opacity-0', isLoaded ? visible : initial);
 
   // Use inline style for custom duration since Tailwind doesn't support arbitrary duration classes
   const style = skipAnimation ? {} : { transitionDuration: `${duration}ms` };

--- a/app/components/FadeIn/FadeIn.tsx
+++ b/app/components/FadeIn/FadeIn.tsx
@@ -1,25 +1,120 @@
 'use client';
+
 import { cn } from '@/app/utils';
+import { useScrollReveal, UseScrollRevealOptions } from '@/app/hooks/useScrollReveal';
 import { ClassValue } from 'clsx';
 import { PropsWithChildren, useEffect, useState } from 'react';
 
-type TextProps = {
+export type FadeInDirection = 'up' | 'down' | 'left' | 'right' | 'none';
+
+export interface FadeInProps {
+  /** Additional CSS classes */
   className?: string | ClassValue;
+  /** Whether to use scroll-triggered animation (default: false for backwards compatibility) */
+  scrollTrigger?: boolean;
+  /** Direction to fade in from (default: 'up') */
+  direction?: FadeInDirection;
+  /** Animation duration in ms (default: 700) */
+  duration?: number;
+  /** Delay before animation starts in ms (default: 0) */
+  delay?: number;
+  /** Intersection Observer options for scroll trigger */
+  scrollOptions?: UseScrollRevealOptions;
+}
+
+const directionStyles: Record<FadeInDirection, { initial: string; visible: string }> = {
+  up: {
+    initial: 'translate-y-5',
+    visible: 'translate-y-0',
+  },
+  down: {
+    initial: '-translate-y-5',
+    visible: 'translate-y-0',
+  },
+  left: {
+    initial: 'translate-x-5',
+    visible: 'translate-x-0',
+  },
+  right: {
+    initial: '-translate-x-5',
+    visible: 'translate-x-0',
+  },
+  none: {
+    initial: '',
+    visible: '',
+  },
 };
 
-export default function FadeIn({ children, className }: PropsWithChildren & TextProps) {
-  const [loaded, setLoaded] = useState<boolean>(false);
+/**
+ * FadeIn component for smooth reveal animations.
+ * Supports both mount-triggered and scroll-triggered animations.
+ *
+ * @example
+ * // Mount-triggered (original behavior)
+ * <FadeIn>Content</FadeIn>
+ *
+ * @example
+ * // Scroll-triggered with direction
+ * <FadeIn scrollTrigger direction="up" delay={200}>
+ *   Content that fades in when scrolled into view
+ * </FadeIn>
+ */
+export default function FadeIn({
+  children,
+  className,
+  scrollTrigger = false,
+  direction = 'up',
+  duration = 700,
+  delay = 0,
+  scrollOptions,
+}: PropsWithChildren<FadeInProps>) {
+  // For mount-triggered animation (backwards compatible)
+  const [mountLoaded, setMountLoaded] = useState<boolean>(false);
+
+  // For scroll-triggered animation
+  const { ref, isVisible, prefersReducedMotion } = useScrollReveal<HTMLDivElement>({
+    delay,
+    ...scrollOptions,
+  });
+
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLoaded(true);
-  }, [setLoaded]);
-  const baseStyle = 'transition-opacity duration-700 ease-in';
+    if (!scrollTrigger) {
+      const timer = delay > 0 ? setTimeout(() => setMountLoaded(true), delay) : null;
+      if (!timer) setMountLoaded(true);
+      return () => {
+        if (timer) clearTimeout(timer);
+      };
+    }
+  }, [scrollTrigger, delay]);
+
+  // Determine visibility based on mode
+  const isLoaded = scrollTrigger ? isVisible : mountLoaded;
+
+  // If user prefers reduced motion, skip animations
+  const skipAnimation = prefersReducedMotion;
+
+  const { initial, visible } = directionStyles[direction];
+
+  const baseStyle = cn(
+    'transition-all ease-out',
+    !skipAnimation && `duration-${duration}`,
+  );
+
+  const animationStyle = skipAnimation
+    ? 'opacity-100'
+    : cn(
+        isLoaded ? 'opacity-100' : 'opacity-0',
+        isLoaded ? visible : initial,
+      );
+
+  // Use inline style for custom duration since Tailwind doesn't support arbitrary duration classes
+  const style = skipAnimation ? {} : { transitionDuration: `${duration}ms` };
+
   return (
     <div
-      className={cn(baseStyle, className, {
-        'opacity-100': loaded,
-        'opacity-0': !loaded,
-      })}
+      ref={scrollTrigger ? ref : undefined}
+      className={cn(baseStyle, animationStyle, className)}
+      style={style}
     >
       {children}
     </div>

--- a/app/components/StatsBar/StatsBar.tsx
+++ b/app/components/StatsBar/StatsBar.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import { cn } from '@/app/utils';
+import { useScrollReveal } from '@/app/hooks/useScrollReveal';
+import { useCountUp } from '@/app/hooks/useCountUp';
 
 export interface StatItem {
   /** The stat value (e.g., "10+", "100+") */
@@ -7,6 +11,10 @@ export interface StatItem {
   label: string;
   /** Optional icon to display */
   icon?: React.ReactNode;
+  /** Numeric value for counter animation (parsed from value if not provided) */
+  numericValue?: number;
+  /** Suffix for counter (e.g., "+", "%") */
+  suffix?: string;
 }
 
 export interface StatsBarProps {
@@ -16,17 +24,81 @@ export interface StatsBarProps {
   variant?: 'default' | 'compact';
   /** Additional CSS classes */
   className?: string;
+  /** Enable counter animation on scroll */
+  animateOnScroll?: boolean;
+  /** Duration for counter animation in ms */
+  animationDuration?: number;
+  /** Stagger delay between items in ms */
+  staggerDelay?: number;
 }
 
-export default function StatsBar({ stats, variant = 'default', className }: StatsBarProps) {
-  const containerStyles = cn(
-    'w-full',
-    variant === 'default'
-      ? 'grid grid-cols-2 gap-4 md:flex md:flex-row md:justify-start md:gap-4 lg:gap-8'
-      : 'grid grid-cols-2 gap-4',
-    className,
+/** Parse numeric value and suffix from stat value string */
+function parseStatValue(value: string): { numeric: number; suffix: string } {
+  const match = value.match(/^(\d+)(.*)$/);
+  if (match) {
+    return { numeric: parseInt(match[1], 10), suffix: match[2] || '' };
+  }
+  return { numeric: 0, suffix: value };
+}
+
+/** Individual stat item with counter animation */
+function AnimatedStatItem({
+  stat,
+  index,
+  isVisible,
+  animationDuration,
+  staggerDelay,
+}: {
+  stat: StatItem;
+  index: number;
+  isVisible: boolean;
+  animationDuration: number;
+  staggerDelay: number;
+}) {
+  const { numeric, suffix } = stat.numericValue !== undefined
+    ? { numeric: stat.numericValue, suffix: stat.suffix || '' }
+    : parseStatValue(stat.value);
+
+  const animatedValue = useCountUp({
+    end: numeric,
+    startCounting: isVisible,
+    duration: animationDuration,
+    suffix,
+  });
+
+  const itemStyles = cn(
+    'flex flex-col items-center justify-center p-4 rounded-lg',
+    'bg-gray-50 transition-all duration-500',
+    'hover:bg-gray-100 hover:shadow-sm',
+    // Staggered fade-in
+    isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4',
   );
 
+  const valueStyles = cn(
+    'text-3xl md:text-3xl lg:text-3xl font-bold',
+    'text-primary bg-gradient-to-r from-primary to-red-600 bg-clip-text text-transparent',
+  );
+
+  const labelStyles = cn('text-sm md:text-base text-gray-600 font-medium mt-1');
+
+  const iconStyles = cn('text-primary mb-2 text-xl md:text-2xl');
+
+  return (
+    <div
+      key={`${stat.label}-${index}`}
+      className={itemStyles}
+      role="listitem"
+      style={{ transitionDelay: `${index * staggerDelay}ms` }}
+    >
+      {stat.icon && <span className={iconStyles}>{stat.icon}</span>}
+      <span className={valueStyles}>{animatedValue}</span>
+      <span className={labelStyles}>{stat.label}</span>
+    </div>
+  );
+}
+
+/** Individual stat item without animation */
+function StaticStatItem({ stat, index }: { stat: StatItem; index: number }) {
   const itemStyles = cn(
     'flex flex-col items-center justify-center p-4 rounded-lg',
     'bg-gray-50 transition-all duration-200',
@@ -43,14 +115,55 @@ export default function StatsBar({ stats, variant = 'default', className }: Stat
   const iconStyles = cn('text-primary mb-2 text-xl md:text-2xl');
 
   return (
-    <div className={containerStyles} role="list" aria-label="Statistics">
-      {stats.map((stat, index) => (
-        <div key={`${stat.label}-${index}`} className={itemStyles} role="listitem">
-          {stat.icon && <span className={iconStyles}>{stat.icon}</span>}
-          <span className={valueStyles}>{stat.value}</span>
-          <span className={labelStyles}>{stat.label}</span>
-        </div>
-      ))}
+    <div key={`${stat.label}-${index}`} className={itemStyles} role="listitem">
+      {stat.icon && <span className={iconStyles}>{stat.icon}</span>}
+      <span className={valueStyles}>{stat.value}</span>
+      <span className={labelStyles}>{stat.label}</span>
+    </div>
+  );
+}
+
+export default function StatsBar({
+  stats,
+  variant = 'default',
+  className,
+  animateOnScroll = false,
+  animationDuration = 2000,
+  staggerDelay = 100,
+}: StatsBarProps) {
+  const { ref, isVisible } = useScrollReveal<HTMLDivElement>({
+    threshold: 0.2,
+  });
+
+  const containerStyles = cn(
+    'w-full',
+    variant === 'default'
+      ? 'grid grid-cols-2 gap-4 md:flex md:flex-row md:justify-start md:gap-4 lg:gap-8'
+      : 'grid grid-cols-2 gap-4',
+    className,
+  );
+
+  return (
+    <div
+      ref={animateOnScroll ? ref : undefined}
+      className={containerStyles}
+      role="list"
+      aria-label="Statistics"
+    >
+      {stats.map((stat, index) =>
+        animateOnScroll ? (
+          <AnimatedStatItem
+            key={`${stat.label}-${index}`}
+            stat={stat}
+            index={index}
+            isVisible={isVisible}
+            animationDuration={animationDuration}
+            staggerDelay={staggerDelay}
+          />
+        ) : (
+          <StaticStatItem key={`${stat.label}-${index}`} stat={stat} index={index} />
+        ),
+      )}
     </div>
   );
 }

--- a/app/components/StatsBar/StatsBar.tsx
+++ b/app/components/StatsBar/StatsBar.tsx
@@ -55,9 +55,10 @@ function AnimatedStatItem({
   animationDuration: number;
   staggerDelay: number;
 }) {
-  const { numeric, suffix } = stat.numericValue !== undefined
-    ? { numeric: stat.numericValue, suffix: stat.suffix || '' }
-    : parseStatValue(stat.value);
+  const { numeric, suffix } =
+    stat.numericValue !== undefined
+      ? { numeric: stat.numericValue, suffix: stat.suffix || '' }
+      : parseStatValue(stat.value);
 
   const animatedValue = useCountUp({
     end: numeric,

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -2,3 +2,5 @@ export * from './useHover';
 export * from './useClickOutside';
 export * from './useDebounce';
 export * from './useBreakpoints';
+export * from './useScrollReveal';
+export * from './useCountUp';

--- a/app/hooks/useCountUp.ts
+++ b/app/hooks/useCountUp.ts
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+
+export interface UseCountUpOptions {
+  /** Starting value, default 0 */
+  start?: number;
+  /** End value to count up to */
+  end: number;
+  /** Duration of animation in ms, default 2000 */
+  duration?: number;
+  /** Whether to start the animation, default false */
+  startCounting?: boolean;
+  /** Easing function, default 'easeOutCubic' */
+  easing?: 'linear' | 'easeOutCubic' | 'easeOutQuart';
+  /** Suffix to append (e.g., '+', '%'), default '' */
+  suffix?: string;
+  /** Prefix to prepend (e.g., '$'), default '' */
+  prefix?: string;
+}
+
+// Easing functions
+const easingFunctions = {
+  linear: (t: number) => t,
+  easeOutCubic: (t: number) => 1 - Math.pow(1 - t, 3),
+  easeOutQuart: (t: number) => 1 - Math.pow(1 - t, 4),
+};
+
+/**
+ * Hook for animating a number counting up.
+ * Works well with useScrollReveal for scroll-triggered counter animations.
+ *
+ * @example
+ * ```tsx
+ * const { ref, isVisible } = useScrollReveal();
+ * const count = useCountUp({ end: 100, startCounting: isVisible, suffix: '+' });
+ *
+ * return <span ref={ref}>{count}</span>;
+ * ```
+ */
+export function useCountUp(options: UseCountUpOptions): string {
+  const {
+    start = 0,
+    end,
+    duration = 2000,
+    startCounting = false,
+    easing = 'easeOutCubic',
+    suffix = '',
+    prefix = '',
+  } = options;
+
+  const [count, setCount] = useState(start);
+  const animationRef = useRef<number | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const hasStartedRef = useRef(false);
+
+  useEffect(() => {
+    // Check for reduced motion preference
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion && startCounting) {
+      setCount(end);
+      return;
+    }
+
+    if (!startCounting || hasStartedRef.current) return;
+
+    hasStartedRef.current = true;
+    const easingFn = easingFunctions[easing];
+
+    const animate = (timestamp: number) => {
+      if (!startTimeRef.current) {
+        startTimeRef.current = timestamp;
+      }
+
+      const elapsed = timestamp - startTimeRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+      const easedProgress = easingFn(progress);
+
+      const currentValue = Math.floor(start + (end - start) * easedProgress);
+      setCount(currentValue);
+
+      if (progress < 1) {
+        animationRef.current = requestAnimationFrame(animate);
+      } else {
+        setCount(end);
+      }
+    };
+
+    animationRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, [startCounting, start, end, duration, easing]);
+
+  return `${prefix}${count}${suffix}`;
+}
+
+export default useCountUp;

--- a/app/hooks/useScrollReveal.ts
+++ b/app/hooks/useScrollReveal.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+export interface UseScrollRevealOptions {
+  /** Threshold for intersection (0-1), default 0.1 */
+  threshold?: number;
+  /** Root margin for earlier/later trigger, default '0px' */
+  rootMargin?: string;
+  /** Only trigger once, default true */
+  once?: boolean;
+  /** Delay before animation starts (ms), default 0 */
+  delay?: number;
+}
+
+export interface UseScrollRevealReturn<T extends HTMLElement> {
+  /** Ref to attach to the element */
+  ref: React.RefObject<T | null>;
+  /** Whether the element is visible/has been revealed */
+  isVisible: boolean;
+  /** Whether reduced motion is preferred */
+  prefersReducedMotion: boolean;
+}
+
+/**
+ * Hook for scroll-triggered reveal animations using Intersection Observer.
+ * Respects user's prefers-reduced-motion preference.
+ *
+ * @example
+ * ```tsx
+ * const { ref, isVisible } = useScrollReveal<HTMLDivElement>();
+ *
+ * return (
+ *   <div
+ *     ref={ref}
+ *     className={cn(
+ *       'transition-all duration-700',
+ *       isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+ *     )}
+ *   >
+ *     Content
+ *   </div>
+ * );
+ * ```
+ */
+export function useScrollReveal<T extends HTMLElement = HTMLDivElement>(
+  options: UseScrollRevealOptions = {},
+): UseScrollRevealReturn<T> {
+  const { threshold = 0.1, rootMargin = '0px', once = true, delay = 0 } = options;
+
+  const ref = useRef<T>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  // Check for reduced motion preference
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setPrefersReducedMotion(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  // If reduced motion is preferred, show immediately
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setIsVisible(true);
+    }
+  }, [prefersReducedMotion]);
+
+  const handleIntersection = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      const [entry] = entries;
+
+      if (entry.isIntersecting) {
+        if (delay > 0) {
+          setTimeout(() => setIsVisible(true), delay);
+        } else {
+          setIsVisible(true);
+        }
+
+        if (once) {
+          observer.disconnect();
+        }
+      } else if (!once) {
+        setIsVisible(false);
+      }
+    },
+    [once, delay],
+  );
+
+  useEffect(() => {
+    // Skip if reduced motion is preferred
+    if (prefersReducedMotion) return;
+
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      threshold,
+      rootMargin,
+    });
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [threshold, rootMargin, handleIntersection, prefersReducedMotion]);
+
+  return { ref, isVisible, prefersReducedMotion };
+}
+
+export default useScrollReveal;

--- a/app/hooks/useScrollReveal.ts
+++ b/app/hooks/useScrollReveal.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, MutableRefObject } from 'react';
 
 export interface UseScrollRevealOptions {
   /** Threshold for intersection (0-1), default 0.1 */
@@ -51,6 +51,8 @@ export function useScrollReveal<T extends HTMLElement = HTMLDivElement>(
   const ref = useRef<T>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  // Track timeout for cleanup to prevent memory leak
+  const timeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null> = useRef(null);
 
   // Check for reduced motion preference
   useEffect(() => {
@@ -78,7 +80,11 @@ export function useScrollReveal<T extends HTMLElement = HTMLDivElement>(
 
       if (entry.isIntersecting) {
         if (delay > 0) {
-          setTimeout(() => setIsVisible(true), delay);
+          // Clear any existing timeout before setting a new one
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+          }
+          timeoutRef.current = setTimeout(() => setIsVisible(true), delay);
         } else {
           setIsVisible(true);
         }
@@ -87,6 +93,11 @@ export function useScrollReveal<T extends HTMLElement = HTMLDivElement>(
           observer.disconnect();
         }
       } else if (!once) {
+        // Clear pending timeout when element leaves view
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+        }
         setIsVisible(false);
       }
     },
@@ -107,7 +118,14 @@ export function useScrollReveal<T extends HTMLElement = HTMLDivElement>(
 
     observer.observe(element);
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      // Clean up any pending timeout to prevent memory leak
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
   }, [threshold, rootMargin, handleIntersection, prefersReducedMotion]);
 
   return { ref, isVisible, prefersReducedMotion };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+// Mock window.matchMedia for components using media queries
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Summary

Implements scroll-triggered animations and polish for the About page (Issue #121).

- Add `useScrollReveal` hook using Intersection Observer API for scroll-triggered reveals
- Add `useCountUp` hook for animated number counting with easing functions
- Enhance `FadeIn` component with `scrollTrigger`, `direction`, and `delay` props
- Enhance `StatsBar` with `animateOnScroll` and staggered counter animations
- Apply scroll-triggered fade-in animations to all About page sections
- Full `prefers-reduced-motion` accessibility support
- Add `window.matchMedia` mock to Jest setup for media query testing
- Add task delegation workflow guideline to CLAUDE.md

## Implementation Approach

Used **Option B: Intersection Observer** as recommended in the issue for a lightweight, dependency-free solution.

## Files Changed

### New Files
- `app/hooks/useScrollReveal.ts` - Scroll reveal hook with a11y support
- `app/hooks/useCountUp.ts` - Counter animation hook with easing

### Modified Files
- `app/hooks/index.ts` - Export new hooks
- `app/components/FadeIn/FadeIn.tsx` - Added scroll trigger support
- `app/components/StatsBar/StatsBar.tsx` - Added counter animations
- `app/[locale]/about/page.tsx` - Applied animations to sections
- `jest.setup.ts` - Added matchMedia mock
- `.claude/CLAUDE.md` - Added task delegation workflow

## Test Plan

- [x] All 385 existing tests pass
- [x] StatsBar counter animations work on scroll
- [x] FadeIn components reveal on scroll
- [x] Staggered delays work correctly
- [x] `prefers-reduced-motion` respected (animations skipped)
- [ ] Manual testing on About page at `/en/about`

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)