### PR TITLE
fix(carousel): resolve persistent loading spinner on re-open (#142)

### DIFF
--- a/__tests__/app/components/ImageCarousel.test.tsx
+++ b/__tests__/app/components/ImageCarousel.test.tsx
@@ -213,4 +213,62 @@ describe('ImageCarousel', () => {
 
     expect(screen.getByText('1 / 3')).toBeInTheDocument();
   });
+
+  test('loads images correctly on remount with same images', async () => {
+    // First mount - simulate opening the card
+    const { container, unmount } = render(<ImageCarousel img={mockImages} />);
+
+    // Images should be present but invisible while loading
+    const wrapper = container.querySelector('[aria-live="polite"]');
+    expect(wrapper).toHaveClass('invisible');
+
+    // Simulate images loading
+    simulateImageLoads(container);
+
+    await waitFor(() => {
+      expect(wrapper).toHaveClass('visible');
+    });
+
+    // Unmount - simulate closing the card
+    unmount();
+
+    // Remount with same images - simulate reopening the card
+    const { container: container2 } = render(<ImageCarousel img={mockImages} />);
+
+    // Images should be invisible while loading (not stuck in loading state)
+    const wrapper2 = container2.querySelector('[aria-live="polite"]');
+    expect(wrapper2).toHaveClass('invisible');
+
+    // Simulate images loading again
+    simulateImageLoads(container2);
+
+    await waitFor(() => {
+      // After images load, wrapper should become visible
+      expect(wrapper2).toHaveClass('visible');
+    });
+
+    // Verify images are rendered correctly
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(3);
+  });
+
+  test('images remain in DOM during loading state for proper load events', () => {
+    const { container } = render(<ImageCarousel img={mockImages} />);
+
+    // Even while loading, images should be in the DOM (not display:none)
+    // so that onLoad events can fire
+    const images = container.querySelectorAll('img');
+    expect(images).toHaveLength(3);
+
+    // Wrapper uses visibility:hidden instead of display:none
+    // so images can still load
+    const wrapper = container.querySelector('[aria-live="polite"]');
+    expect(wrapper).toHaveClass('invisible');
+
+    // Verify images are not set to display:none
+    images.forEach((img) => {
+      const computedStyle = window.getComputedStyle(img);
+      expect(computedStyle.display).not.toBe('none');
+    });
+  });
 });

--- a/__tests__/app/components/ImageCarousel.test.tsx
+++ b/__tests__/app/components/ImageCarousel.test.tsx
@@ -168,8 +168,9 @@ describe('ImageCarousel', () => {
     expect(screen.getByLabelText('Next image')).toBeInTheDocument();
   });
 
-  test('resets to first image when img prop changes', () => {
-    const { rerender } = render(<ImageCarousel img={mockImages} />);
+  test('resets to first image when remounted with different images (key change)', () => {
+    // First mount with initial images
+    const { unmount } = render(<ImageCarousel img={mockImages} />);
 
     const nextButton = screen.getByLabelText('Next image');
 
@@ -177,11 +178,14 @@ describe('ImageCarousel', () => {
     fireEvent.click(nextButton);
     expect(screen.getByText('2 / 3')).toBeInTheDocument();
 
-    // Change images
-    const newImages = ['https://example.com/new1.jpg', 'https://example.com/new2.jpg'];
-    rerender(<ImageCarousel img={newImages} />);
+    // Unmount (simulates key change in parent causing remount)
+    unmount();
 
-    // Should reset to first image
+    // Remount with different images (simulates key change)
+    const newImages = ['https://example.com/new1.jpg', 'https://example.com/new2.jpg'];
+    render(<ImageCarousel img={newImages} />);
+
+    // Should start at first image (fresh state from remount)
     expect(screen.getByText('1 / 2')).toBeInTheDocument();
   });
 

--- a/app/components/ImageCarousel/ImageCarousel.tsx
+++ b/app/components/ImageCarousel/ImageCarousel.tsx
@@ -3,7 +3,7 @@
 
 import { cn } from '@/app/utils';
 import { ClassValue } from 'clsx';
-import { useCallback, useState, useEffect, memo, useRef, useMemo, useTransition } from 'react';
+import { useCallback, useState, useEffect, memo, useRef, useMemo } from 'react';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { TbLoader2 } from 'react-icons/tb';
 
@@ -14,48 +14,24 @@ interface ImageCarouselProps {
 
 function ImageCarousel({ img, customClass }: ImageCarouselProps) {
   const [currImg, setCurrImg] = useState<number>(0);
+  const [loadedImages, setLoadedImages] = useState<Set<string>>(new Set());
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const [isPending, startTransition] = useTransition();
-  const [loadedImages, setLoadedImages] = useState<Set<string>>(new Set());
-  const [displayImages, setDisplayImages] = useState<string[]>(img);
+  const isLoading = loadedImages.size < img.length;
 
-  // Track previous images to detect actual changes vs remounts
-  const prevImgRef = useRef<string[]>(img);
-
-  const isLoading = useMemo(
-    () => isPending || loadedImages.size < displayImages.length,
-    [isPending, loadedImages.size, displayImages.length],
-  );
-
+  // Reset state when images change
   useEffect(() => {
-    const prevImg = prevImgRef.current;
-    // Check if images actually changed (not just remount with same images)
-    const imagesChanged =
-      img.length !== prevImg.length || img.some((src, i) => src !== prevImg[i]);
-
-    prevImgRef.current = img;
-
-    // Skip reset on remount with same images to avoid race condition
-    // where startTransition might reset loadedImages after cached images loaded
-    if (!imagesChanged) return;
-
-    // Reset index immediately when images change (outside transition)
     setCurrImg(0);
-
-    startTransition(() => {
-      setLoadedImages(new Set());
-      setDisplayImages(img);
-    });
+    setLoadedImages(new Set());
   }, [img]);
 
   const onClickLeft = useCallback(() => {
-    setCurrImg((index) => (index - 1 + displayImages.length) % displayImages.length);
-  }, [displayImages.length]);
+    setCurrImg((index) => (index - 1 + img.length) % img.length);
+  }, [img.length]);
 
   const onClickRight = useCallback(() => {
-    setCurrImg((index) => (index + 1) % displayImages.length);
-  }, [displayImages.length]);
+    setCurrImg((index) => (index + 1) % img.length);
+  }, [img.length]);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -87,8 +63,7 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
     });
   }, []);
 
-  // Use displayImages.length for consistency between indicator and carousel
-  const offset = useMemo(() => 100 / displayImages.length, [displayImages.length]);
+  const offset = useMemo(() => 100 / img.length, [img.length]);
 
   useEffect(() => {
     if (wrapperRef.current) {
@@ -107,7 +82,7 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
       <div
         ref={wrapperRef}
         style={{
-          width: `${displayImages.length * 100}%`,
+          width: `${img.length * 100}%`,
         }}
         className={cn(
           'h-full flex transition-transform ease-in-out',
@@ -115,14 +90,14 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
         )}
         aria-live="polite"
       >
-        {displayImages.map((src, i) => {
+        {img.map((src, i) => {
           return (
             <img
               key={`${src}-${i}`}
-              style={{ width: `${100 / displayImages.length}%` }}
+              style={{ width: `${100 / img.length}%` }}
               className={'h-full object-cover'}
               src={src}
-              alt={`Image ${i + 1} of ${displayImages.length}`}
+              alt={`Image ${i + 1} of ${img.length}`}
               onLoad={() => handleImageLoad(src)}
               draggable="false"
             />
@@ -148,7 +123,7 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
         className={cn(currImgIndicatorBaseStyle, customClass)}
         aria-live="polite"
         aria-atomic="true"
-      >{`${currImg + 1} / ${displayImages.length}`}</div>
+      >{`${currImg + 1} / ${img.length}`}</div>
     </div>
   );
 }

--- a/app/components/ImageCarousel/ImageCarousel.tsx
+++ b/app/components/ImageCarousel/ImageCarousel.tsx
@@ -94,9 +94,11 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
         ref={wrapperRef}
         style={{
           width: `${displayImages.length * 100}%`,
-          display: isLoading ? 'none' : 'flex',
         }}
-        className="h-full transition-transform ease-in-out"
+        className={cn(
+          'h-full transition-transform ease-in-out',
+          isLoading ? 'invisible' : 'visible flex',
+        )}
         aria-live="polite"
       >
         {displayImages.map((src, i) => {

--- a/app/components/ImageCarousel/ImageCarousel.tsx
+++ b/app/components/ImageCarousel/ImageCarousel.tsx
@@ -19,11 +19,8 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
 
   const isLoading = loadedImages.size < img.length;
 
-  // Reset state when images change
-  useEffect(() => {
-    setCurrImg(0);
-    setLoadedImages(new Set());
-  }, [img]);
+  // Note: State reset is handled by React's key-based remounting in PlaceContent
+  // When heritage changes, ImageCarousel gets a new key and remounts with fresh state
 
   const onClickLeft = useCallback(() => {
     setCurrImg((index) => (index - 1 + img.length) % img.length);

--- a/app/components/ImageCarousel/ImageCarousel.tsx
+++ b/app/components/ImageCarousel/ImageCarousel.tsx
@@ -20,12 +20,26 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
   const [loadedImages, setLoadedImages] = useState<Set<string>>(new Set());
   const [displayImages, setDisplayImages] = useState<string[]>(img);
 
+  // Track previous images to detect actual changes vs remounts
+  const prevImgRef = useRef<string[]>(img);
+
   const isLoading = useMemo(
     () => isPending || loadedImages.size < displayImages.length,
     [isPending, loadedImages.size, displayImages.length],
   );
 
   useEffect(() => {
+    const prevImg = prevImgRef.current;
+    // Check if images actually changed (not just remount with same images)
+    const imagesChanged =
+      img.length !== prevImg.length || img.some((src, i) => src !== prevImg[i]);
+
+    prevImgRef.current = img;
+
+    // Skip reset on remount with same images to avoid race condition
+    // where startTransition might reset loadedImages after cached images loaded
+    if (!imagesChanged) return;
+
     // Reset index immediately when images change (outside transition)
     setCurrImg(0);
 
@@ -82,7 +96,7 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
     }
   }, [currImg, offset]);
 
-  const containerBaseStyle = 'w-full h-full relative overflow-x-hidden bg-white';
+  const containerBaseStyle = 'w-full h-full relative overflow-hidden bg-white';
   const navBtnBaseStyle =
     'absolute top-[50%] opacity-80 text-white rounded-full cursor-pointer text-3xl max-sm:text-4xl flex';
   const currImgIndicatorBaseStyle =
@@ -96,8 +110,8 @@ function ImageCarousel({ img, customClass }: ImageCarouselProps) {
           width: `${displayImages.length * 100}%`,
         }}
         className={cn(
-          'h-full transition-transform ease-in-out',
-          isLoading ? 'invisible' : 'visible flex',
+          'h-full flex transition-transform ease-in-out',
+          isLoading ? 'invisible' : 'visible',
         )}
         aria-live="polite"
       >

--- a/app/components/PlaceContent/PlaceContent.tsx
+++ b/app/components/PlaceContent/PlaceContent.tsx
@@ -41,7 +41,7 @@ function PlaceContent() {
     >
       {/** Carousel Container */}
       <div className={'w-full h-[280px]'}>
-        <ImageCarousel img={data.imgSource} customClass={getThemeStyle()} />
+        <ImageCarousel key={data.id} img={data.imgSource} customClass={getThemeStyle()} />
       </div>
       <div className={'absolute top-1 w-full px-4'}>
         <ButtonContainer />


### PR DESCRIPTION
## Summary

Fixes the ImageCarousel persistent loading spinner bug when reopening PlaceContent after closing.

**Root cause:** Race condition between `useEffect` state reset and `onLoad` events for cached images. The state reset could overwrite loaded state after images had already fired their `onLoad` events.

## Changes

- **PlaceContent.tsx**: Added `key={data.id}` to ImageCarousel for key-based remounting
- **ImageCarousel.tsx**: 
  - Removed `useEffect` that reset state (source of race condition)
  - Removed unnecessary `useTransition`, `displayImages` state, `prevImgRef`
  - Changed `overflow-x-hidden` to `overflow-hidden`
  - Ensured `flex` is always applied to image wrapper
- **ImageCarousel.test.tsx**: Updated test for key-based remounting behavior

## How it works

| Scenario | Behavior |
|----------|----------|
| Heritage changes (A → B) | Key changes → ImageCarousel remounts with fresh state |
| Close and reopen same heritage | PlaceContent unmounts → ImageCarousel remounts fresh |
| Initial open | Fresh mount with `useState` initial values |

## Checklist

- [x] Lint passing (Husky pre-commit)
- [x] Tests passing (440 tests)
- [x] Build successful (Husky pre-push)
- [ ] Manual testing

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)